### PR TITLE
Extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # vue-safe-html
-A Vue directive which renders sanitised HTML dynamically
+
+A Vue directive which renders sanitised HTML dynamically. Zero-dependency,
+
+## Installation
+
+Install package:
+
+```sh
+npm install @ecosia/vue-safe-html
+# OR
+yarn add @ecosia/vue-safe-html
+```
+
+Use the plugin:
+
+```js
+import Vue from 'vue';
+import VueSafeHTML from '@ecosia/vue-safe-html';
+
+Vue.use(VueSafeHTML);
+```
+
+## Usage
+
+In your component:
+
+```html
+<template>
+  <div vue-safe-html="myUnsafeHTML">
+</template>
+```
+
+```js
+export default {
+  computed: {
+    myUnsafeHTML() {
+      return '<script>oh my!</script> I am safe!';
+    }
+  }
+}
+```
+
+Renders to:
+
+```html
+<div>I am safe!</div>
+```
+
+### Options
+
+#### allowedTags
+
+Array. Default: `['a', 'b', 'br', 'strong', 'i', 'em', 'mark', 'small', 'del', 'ins', 'sub', 'sup']`
+
+Customize the tags that are allowed to be rendered, either by providing new ones:
+
+```js
+Vue.use(VueSafeHTML, {
+  allowedTags: ['marquee', 'blockquote'],
+});
+```
+
+Or extending the default ones:
+
+```js
+import VueSafeHTML, { allowedTags } from '@ecosia/vue-safe-html';
+
+Vue.use(VueSafeHTML, {
+  allowedTags: [...allowedTags, 'marquee', 'blockquote'],
+});
+```
+
+## License
+
+[MIT](./LICENSE)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable import/prefer-default-export */
 import Vue from 'vue';
-
 import directive from './directive';
 
 Vue.directive('safe-html', directive);


### PR DESCRIPTION
Adds basic installation and usage doc. It implies that `index.js` is the plugin file that initializes the directive and package.json points to distribution (UMD?) `index.js` file.