### PR TITLE
CI naming + npmignoring yarn.lock

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,11 @@
-name: Install + Test + Build
+name: CI
 on:
   push:
     branches:
       - "*"
 jobs:
   build:
-    name: Test
+    name: Install + Test + Build
     runs-on: ubuntu-latest
     container: node:14.15-alpine
     steps:

--- a/.npmignore
+++ b/.npmignore
@@ -7,3 +7,4 @@ jest.config.js
 webpack.config.js
 *.test.js
 src
+yarn.lock


### PR DESCRIPTION
according to [sources](https://stackoverflow.com/a/40206145/2451504) libraries should not include their yarn lock in the NPM packages.

Also renamed the Github workflow so it makes more sense in the Github UI.