### PR TITLE
Add plugin type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,4 @@
+import { Plugin } from '@vue/runtime-core';
+
+declare const plugin: Plugin;
+export default plugin;


### PR DESCRIPTION
Tested including the plugin in a throwaway vue-cli-made vue 3 app with typescript plugin:

```js
// …
import SafeHTML from '../../src/index.js';

createApp(app)
  .use(SafeHTML)
  .mount('#app')
```

Closes #13 