### PR TITLE
Add ecosia to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue-safe-html",
+  "name": "@ecosia/vue-safe-html",
   "version": "1.0.0",
   "description": "A Vue directive which renders sanitised HTML dynamically",
   "main": "dist/main.js",


### PR DESCRIPTION
In our README we currently name the package `@ecosia/vue-safe-html` this should be reflected in our package json. 
I could also imagine to just call the package `vue-safe-html`. What do you think?