### PR TITLE
Fix self is not defined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
     path: resolve(__dirname, 'dist'),
     library: 'VueSafeHTML',
     libraryTarget: 'umd',
+    globalObject: `(typeof self !== 'undefined' ? self : this)`,
   },
   mode: 'production',
   module: {


### PR DESCRIPTION
When using the current UMD build of the plugin server side I get the error: `self is not defined`
This seems to be an issue with the build which webpack produces: https://github.com/webpack/webpack/issues/6525

I found that it can be fixed by adding `globalObject: `(typeof self !== 'undefined' ? self : this)` to the webpack config which seems to work well.