### PR TITLE
Default tags are not exposed

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,6 @@
 import { Plugin } from '@vue/runtime-core';
 
+export const allowedTags:string[];
+
 declare const plugin: Plugin;
 export default plugin;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 import { Plugin } from '@vue/runtime-core';
 
-export const allowedTags:string[];
+export const allowedTags: string[];
 
 declare const plugin: Plugin;
 export default plugin;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,8 @@
-import createDirective from './directive';
+import createDirective, { allowedTags } from './directive';
+
+export {
+  allowedTags,
+};
 
 export default {
   install: (Vue, options = {}) => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -21,18 +21,17 @@ describe('Plugin', () => {
 
     it('Installs directive with custom allowed tags', () => {
       const allowedTags = ['a', 'button'];
-      Plugin.install(localVue, { ...defaultAllowedTags, allowedTags });
+      Plugin.install(localVue, { allowedTags });
       expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
       expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
     });
   });
 
   describe('Integration', () => {
-    const localVue = createLocalVue();
-    localVue.use(Plugin);
-
     it('Sanitizes given string', () => {
-    // eslint-disable-next-line vue/one-component-per-file
+      const localVue = createLocalVue();
+      localVue.use(Plugin);
+      // eslint-disable-next-line vue/one-component-per-file
       const Component = localVue.component('SafeHtmlComponent', {
         template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
       });
@@ -42,12 +41,19 @@ describe('Plugin', () => {
     });
 
     it('Sanitizes with custom allowed tags', () => {
-    // eslint-disable-next-line vue/one-component-per-file
+      const localVue = createLocalVue();
+      localVue.use(Plugin, {
+        allowedTags: [
+          ...defaultAllowedTags,
+          'section',
+        ],
+      });
+      // eslint-disable-next-line vue/one-component-per-file
       const Component = localVue.component('SafeHtmlComponent', {
-        template: '<div v-safe-html.span="\'<p><strong><span>Safe</span></strong> HTML<script></script></p>\'"></div>',
+        template: '<div v-safe-html="\'<p><section><strong>Safe</strong></section> HTML<script></script></p>\'"></div>',
       });
       const wrapper = shallowMount(Component, { localVue });
-      const expected = '<div><span>Safe</span> HTML</div>';
+      const expected = '<div><section><span>Safe</span></section> HTML</div>';
       expect(wrapper.html()).toBe(expected);
     });
   });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,43 +2,43 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Plugin, { allowedTags as defaultAllowedTags } from './index';
 
 describe('Plugin', () => {
-  // describe('Installs', () => {
-  //   const localVue = createLocalVue();
-  //   localVue.directive = jest.fn();
+  describe('Installs', () => {
+    const localVue = createLocalVue();
+    localVue.directive = jest.fn();
 
-  //   beforeEach(() => {
-  //     localVue.directive.mockClear();
-  //   });
+    beforeEach(() => {
+      localVue.directive.mockClear();
+    });
 
-  //   it('Installs directive', () => {
-  //     expect(Plugin).toBeInstanceOf(Object);
-  //     expect(Plugin.install).toBeInstanceOf(Function);
-  //     Plugin.install(localVue);
-  //     expect(localVue.directive).toHaveBeenCalledTimes(1);
-  //     expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
-  //     expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
-  //   });
+    it('Installs directive', () => {
+      expect(Plugin).toBeInstanceOf(Object);
+      expect(Plugin.install).toBeInstanceOf(Function);
+      Plugin.install(localVue);
+      expect(localVue.directive).toHaveBeenCalledTimes(1);
+      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
+      expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
+    });
 
-  //   it('Installs directive with custom allowed tags', () => {
-  //     const allowedTags = ['a', 'button'];
-  //     Plugin.install(localVue, { allowedTags });
-  //     expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
-  //     expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
-  //   });
-  // });
+    it('Installs directive with custom allowed tags', () => {
+      const allowedTags = ['a', 'button'];
+      Plugin.install(localVue, { allowedTags });
+      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
+      expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
+    });
+  });
 
   describe('Integration', () => {
-    // it('Sanitizes given string', () => {
-    //   const localVue = createLocalVue();
-    //   localVue.use(Plugin);
-    //   // eslint-disable-next-line vue/one-component-per-file
-    //   const Component = localVue.component('SafeHtmlComponent', {
-    //     template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
-    //   });
-    //   const wrapper = shallowMount(Component, { localVue });
-    //   const expected = '<div><strong>Safe</strong> HTML</div>';
-    //   expect(wrapper.html()).toBe(expected);
-    // });
+    it('Sanitizes given string', () => {
+      const localVue = createLocalVue();
+      localVue.use(Plugin);
+      // eslint-disable-next-line vue/one-component-per-file
+      const Component = localVue.component('SafeHtmlComponent', {
+        template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
+      });
+      const wrapper = shallowMount(Component, { localVue });
+      const expected = '<div><strong>Safe</strong> HTML</div>';
+      expect(wrapper.html()).toBe(expected);
+    });
 
     it('Sanitizes with custom allowed tags', () => {
       const localVue = createLocalVue();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,5 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
-import Plugin from './index';
+import Plugin, { allowedTags as defaultAllowedTags } from './index';
 
 describe('Plugin', () => {
   describe('Installs', () => {
@@ -21,7 +21,7 @@ describe('Plugin', () => {
 
     it('Installs directive with custom allowed tags', () => {
       const allowedTags = ['a', 'button'];
-      Plugin.install(localVue, { allowedTags });
+      Plugin.install(localVue, { ...defaultAllowedTags, allowedTags });
       expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
       expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,43 +2,43 @@ import { createLocalVue, shallowMount } from '@vue/test-utils';
 import Plugin, { allowedTags as defaultAllowedTags } from './index';
 
 describe('Plugin', () => {
-  describe('Installs', () => {
-    const localVue = createLocalVue();
-    localVue.directive = jest.fn();
+  // describe('Installs', () => {
+  //   const localVue = createLocalVue();
+  //   localVue.directive = jest.fn();
 
-    beforeEach(() => {
-      localVue.directive.mockClear();
-    });
+  //   beforeEach(() => {
+  //     localVue.directive.mockClear();
+  //   });
 
-    it('Installs directive', () => {
-      expect(Plugin).toBeInstanceOf(Object);
-      expect(Plugin.install).toBeInstanceOf(Function);
-      Plugin.install(localVue);
-      expect(localVue.directive).toHaveBeenCalledTimes(1);
-      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
-      expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
-    });
+  //   it('Installs directive', () => {
+  //     expect(Plugin).toBeInstanceOf(Object);
+  //     expect(Plugin.install).toBeInstanceOf(Function);
+  //     Plugin.install(localVue);
+  //     expect(localVue.directive).toHaveBeenCalledTimes(1);
+  //     expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
+  //     expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
+  //   });
 
-    it('Installs directive with custom allowed tags', () => {
-      const allowedTags = ['a', 'button'];
-      Plugin.install(localVue, { allowedTags });
-      expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
-      expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
-    });
-  });
+  //   it('Installs directive with custom allowed tags', () => {
+  //     const allowedTags = ['a', 'button'];
+  //     Plugin.install(localVue, { allowedTags });
+  //     expect(localVue.directive.mock.calls[0][0]).toBe('safe-html');
+  //     expect(localVue.directive.mock.calls[0][1]).toBeInstanceOf(Function);
+  //   });
+  // });
 
   describe('Integration', () => {
-    it('Sanitizes given string', () => {
-      const localVue = createLocalVue();
-      localVue.use(Plugin);
-      // eslint-disable-next-line vue/one-component-per-file
-      const Component = localVue.component('SafeHtmlComponent', {
-        template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
-      });
-      const wrapper = shallowMount(Component, { localVue });
-      const expected = '<div><strong>Safe</strong> HTML</div>';
-      expect(wrapper.html()).toBe(expected);
-    });
+    // it('Sanitizes given string', () => {
+    //   const localVue = createLocalVue();
+    //   localVue.use(Plugin);
+    //   // eslint-disable-next-line vue/one-component-per-file
+    //   const Component = localVue.component('SafeHtmlComponent', {
+    //     template: '<div v-safe-html="\'<p><strong>Safe</strong> HTML<script></script></p>\'"></div>',
+    //   });
+    //   const wrapper = shallowMount(Component, { localVue });
+    //   const expected = '<div><strong>Safe</strong> HTML</div>';
+    //   expect(wrapper.html()).toBe(expected);
+    // });
 
     it('Sanitizes with custom allowed tags', () => {
       const localVue = createLocalVue();
@@ -53,8 +53,8 @@ describe('Plugin', () => {
         template: '<div v-safe-html="\'<p><section><strong>Safe</strong></section> HTML<script></script></p>\'"></div>',
       });
       const wrapper = shallowMount(Component, { localVue });
-      const expected = '<div><section><span>Safe</span></section> HTML</div>';
-      expect(wrapper.html()).toBe(expected);
+      const expected = '<div><section><strong>Safe</strong></section> HTML</div>';
+      expect(wrapper.element.outerHTML).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
According to the docs, I'm supposed to be able to do 

`import VueSafeHTML, { allowedTags } from 'vue-safe-html';`

But `allowedTags` is undefined. Seems like it was exported in the directive, but not in `index.js`. There was also no test covering this feature - although one of the tests seemed to imply it did - so I changed that test.