### PR TITLE
Improve sanitizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-safe-html",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A Vue directive which renders sanitised HTML dynamically",
   "main": "dist/main.js",
   "repository": "git@github.com:ecosia/vue-safe-html.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-safe-html",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A Vue directive which renders sanitised HTML dynamically",
   "main": "dist/main.js",
   "repository": "git@github.com:ecosia/vue-safe-html.git",

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,6 @@
 export const sanitizeHTML = (htmlString, allowedTags = []) => {
   // Add an optional white space to the allowed tags
   const allowedTagsWhiteSpaced = allowedTags.map((tag) => `${tag}\\s*`);
-  //const htmlAttributeRegex = new RegExp('<\\w*\\s*(\\w*[-]?\\w*=[\",\'].*[\",\'])>');
 
   // Remove tag attributes
   // The solution for this was found on:

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,9 +23,9 @@ export const sanitizeHTML = (htmlString, allowedTags = []) => {
     // ')' close the matching group of negative lookup
     // '\w*[^<>]*' matches any word that isn't in the excluded group
     // '>' Match closing tagq
-    `<(?!\\s*\/?\\s*(${allowedTags.join('|')})>)\\w*[^<>]*>` :
+    `<(?!\\s*\\/?\\s*(${allowedTagsWhiteSpaced.join('|')})>)\\w*[^<>]*>` :
     // Strips all tags
-    '<(\/?\\w*)\\w*[^<>]*>';
+    '<(\\/?\\w*)\\w*[^<>]*>';
 
   const regExp = new RegExp(expression, 'gm');
   return htmlString.replace(regExp, '');

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,9 +6,27 @@
  */
 // eslint-disable-next-line import/prefer-default-export
 export const sanitizeHTML = (htmlString, allowedTags = []) => {
+  // Add an optional white space to the allowed tags
+  const allowedTagsWhiteSpaced = allowedTags.map((tag) => `${tag}\\s*`);
+
   const expression = (allowedTags.length > 0) ?
-    `<(?!((?:/s*)?(?:${allowedTags.join('|')})))([^>])+>` :
-    '<[^>]*>';
-  const regExp = new RegExp(expression, 'g');
+    // Regex explanation
+    // Note: \ needs to be escaped in the final expression
+    // '<' Match the starting tag
+    // '(' Create a matching group
+    // '?!' Use negative lookup
+    //      we only want to match the tags that are not in the allowedTags array
+    // '\s*?' Optional match of any white space charater before optional /
+    // '\/?' Matches / zero to one time for the closing tag
+    // '\s*?' Optional match of any white space charater after optional /
+    // '(${allowedTags.join('\s*|')})>' matching group of the allowed tags
+    // ')' close the matching group of negative lookup
+    // '\w*[^<>]*' matches any word that isn't in the excluded group
+    // '>' Match closing tagq
+    `<(?!\\s*\/?\\s*(${allowedTags.join('|')})>)\\w*[^<>]*>` :
+    // Strips all tags
+    '<(\/?\\w*)\\w*[^<>]*>';
+
+  const regExp = new RegExp(expression, 'gm');
   return htmlString.replace(regExp, '');
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,8 @@ export const sanitizeHTML = (htmlString, allowedTags = []) => {
   //const htmlAttributeRegex = new RegExp('<\\w*\\s*(\\w*[-]?\\w*=[\",\'].*[\",\'])>');
 
   // Remove tag attributes
+  // The solution for this was found on:
+  // https://stackoverflow.com/questions/4885891/regex-for-removing-all-attributes-from-a-paragraph
   const htmlWithoutAttributes = htmlString.replace(/<(\w+)(.|[\r\n])*?>/g, '<$1>');
 
   const expression = (allowedTags.length > 0) ?

--- a/src/utils.js
+++ b/src/utils.js
@@ -19,7 +19,7 @@ export const sanitizeHTML = (htmlString, allowedTags = []) => {
     // '\s*?' Optional match of any white space charater before optional /
     // '\/?' Matches / zero to one time for the closing tag
     // '\s*?' Optional match of any white space charater after optional /
-    // '(${allowedTags.join('\s*|')})>' matching group of the allowed tags
+    // '(${allowedTags.join('|')})>' matching group of the allowed tags
     // ')' close the matching group of negative lookup
     // '\w*[^<>]*' matches any word that isn't in the excluded group
     // '>' Match closing tagq

--- a/src/utils.js
+++ b/src/utils.js
@@ -8,6 +8,10 @@
 export const sanitizeHTML = (htmlString, allowedTags = []) => {
   // Add an optional white space to the allowed tags
   const allowedTagsWhiteSpaced = allowedTags.map((tag) => `${tag}\\s*`);
+  //const htmlAttributeRegex = new RegExp('<\\w*\\s*(\\w*[-]?\\w*=[\",\'].*[\",\'])>');
+
+  // Remove tag attributes
+  const htmlWithoutAttributes = htmlString.replace(/<(\w+)(.|[\r\n])*?>/g, '<$1>');
 
   const expression = (allowedTags.length > 0) ?
     // Regex explanation
@@ -28,5 +32,5 @@ export const sanitizeHTML = (htmlString, allowedTags = []) => {
     '<(\\/?\\w*)\\w*[^<>]*>';
 
   const regExp = new RegExp(expression, 'gm');
-  return htmlString.replace(regExp, '');
+  return htmlWithoutAttributes.replace(regExp, '');
 };

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -42,5 +42,12 @@ describe('Utils', () => {
       const expected = 'Test1 Test2 Test3';
       expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
     });
+
+    it('Removes attributes from html', () => {
+      const allowedTags = ['p'];
+      const given = '<p data-test="test" title="test2">Test1</p> <strong data-test=\'test2\'>Test2</strong>';
+      const expected = '<p>Test1</p> Test2';
+      expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
+    });
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -17,7 +17,7 @@ describe('Utils', () => {
 
     it('Strips input tags', () => {
       const allowedTags = ['strong', 'i'];
-      const given = '<p><i>An</i> <strong>input field</strong><input type="button"></p>';
+      const given = '<p><i>An</i> <strong>input field</strong><input type="button" /></p>';
       const expected = '<i>An</i> <strong>input field</strong>';
       expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
     });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -23,9 +23,9 @@ describe('Utils', () => {
     });
 
     it('Strips similar tags', () => {
-      const allowedTags = ['p'];
-      const given = '<sp>Test1</sp> <sssp>Test2</sssp>';
-      const expected = 'Test1 Test2';
+      const allowedTags = ['p', 'b', 's'];
+      const given = '<sp>Test1</sp> <sssp>Test2</sssp><script></script> <blockquote>quote</blockquote>';
+      const expected = 'Test1 Test2 quote';
       expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
     });
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -35,5 +35,12 @@ describe('Utils', () => {
       const expected = '<p>Test1</ p><p>Test2</  p>';
       expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
     });
+
+    it('Removes all tags with empty allowed tags', () => {
+      const allowedTags = [];
+      const given = '<p>Test1</p> <strong  >Test2</strong> <  i>Test3</i>';
+      const expected = 'Test1 Test2 Test3';
+      expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
+    });
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -14,5 +14,26 @@ describe('Utils', () => {
       const expected = 'An html<br><strong>string</strong>';
       expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
     });
+
+    it('Strips input tags', () => {
+      const allowedTags = ['strong', 'i'];
+      const given = '<p><i>An</i> <strong>input field</strong><input type="button"></p>';
+      const expected = '<i>An</i> <strong>input field</strong>';
+      expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
+    });
+
+    it('Strips similar tags', () => {
+      const allowedTags = ['p'];
+      const given = '<sp>Test1</sp> <sssp>Test2</sssp>';
+      const expected = 'Test1 Test2';
+      expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
+    });
+
+    it('Considers whitespaces', () => {
+      const allowedTags = ['p'];
+      const given = '<p>Test1</ p><p>Test2</  p>';
+      const expected = '<p>Test1</ p><p>Test2</  p>';
+      expect(utils.sanitizeHTML(given, allowedTags)).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
I took a deep look at the current regular expression and rewrote it to fix all current issues.

Fixes:
- https://github.com/ecosia/vue-safe-html/issues/67
- https://github.com/ecosia/vue-safe-html/issues/48
- https://github.com/ecosia/vue-safe-html/issues/66 

Furthermore I added a comment to explain the regular expression we're using.
Something we need to think about is if we want to support html attributes. At the moment, if tags include attributes the are stripped for completely.

I am not sure if we want to add this since it adds some complexity to this library. If we think this is needed we might want to think about just using https://github.com/apostrophecms/sanitize-html which offers a lot of configuration possibilities.

