### PR TITLE
Add note to README that it’s not XSS-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A Vue directive which renders sanitised HTML dynamically. Zero dependencies, compatible with Vue versions 3 and 2, TypeScript-ready.
 
+**Note:** This library is not XSS-safe, but only strips tags programmatically.
+
 ## Installation
 
 Install package:


### PR DESCRIPTION
Adds note to  README specifying that it’s not XSS-safe, but only strips tags programmatically.