### PR TITLE
Add support for stripping all tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Vue.use(VueSafeHTML);
 
 In your component:
 
-```html
+```jsx
 <template>
-  <div v-safe-html="myUnsafeHTML">
+  <div v-safe-html="myUnsafeHTML" />
 </template>
 ```
 
@@ -91,11 +91,38 @@ Vue.use(VueSafeHTML, {
 
 It is also possible to provide custom allowed tags directly to the directive tag, using directive modifiers. This allows local override of the option:
 
-```html
+```jsx
 <template>
-  <!-- only allow p and strong tags -->
-  <div v-safe-html.p.strong="myUnsafeHTML">
+  <div v-safe-html.p.strong="myUnsafeHTML" />
 </template>
+```
+
+> Only allow p and strong tags
+
+#### Stripping all tags for HTML entity decoding
+
+To decode HTML entities only with no tags you can use the `strip-tags` directive argument:
+
+```jsx
+<template>
+  <div v-safe-html:strip-tags="unsafeHTML" />
+</template>
+```
+
+```js
+export default {
+  computed: {
+    myUnsafeHTML() {
+      return '<p><strong>Cats<strong> &amp; <em>&quot;Dogs&quot;</em></p>';
+    }
+  }
+}
+```
+
+Renders to:
+
+```html
+<div>Cats &amp; "Dogs"</div>
 ```
 
 ### Nuxt

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-safe-html",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A Vue directive which renders sanitised HTML dynamically",
   "main": "dist/main.js",
   "repository": "git@github.com:ecosia/vue-safe-html.git",

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -62,5 +62,43 @@ describe('Plugin', () => {
       const expected = '<div><section><strong>Safe</strong></section> HTML</div>';
       expect(wrapper.element.outerHTML).toBe(expected);
     });
+
+    describe('Modifiers', () => {
+      it('Handles allowed tags as modifiers', () => {
+        const localVue = createLocalVue();
+        localVue.use(Plugin, {
+          allowedTags: [
+            ...defaultAllowedTags,
+            'section',
+          ],
+        });
+        // eslint-disable-next-line vue/one-component-per-file
+        const Component = localVue.component('SafeHtmlComponent', {
+          template: '<div v-safe-html.p.strong="\'<p><section><strong>Safe</strong></section> HTML<script></script> &amp; <mark>marked text</mark></p>\'"></div>',
+        });
+        const wrapper = shallowMount(Component, { localVue });
+        const expected = '<div><p><strong>Safe</strong> HTML &amp; marked text</p></div>';
+        expect(wrapper.element.outerHTML).toBe(expected);
+      });
+    });
+
+    describe('"strip-tags" argument', () => {
+      it('strips all HTML but leaves HTML entities', () => {
+        const localVue = createLocalVue();
+        localVue.use(Plugin, {
+          allowedTags: [
+            ...defaultAllowedTags,
+            'section',
+          ],
+        });
+        // eslint-disable-next-line vue/one-component-per-file
+        const Component = localVue.component('SafeHtmlComponent', {
+          template: '<div v-safe-html:strip-tags="\'<p><strong>Cats<strong> &amp; <em>&quot;Dogs&quot;</em></p>\'"></div>',
+        });
+        const wrapper = shallowMount(Component, { localVue });
+        const expected = '<div>Cats &amp; "Dogs"</div>';
+        expect(wrapper.element.outerHTML).toBe(expected);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds the ability to render HTML entities without any HTML:

```jsx
<template>
  <div v-safe-html:strip-tags="'<p><strong>Cats<strong> &amp; <em>&quot;Dogs&quot;</em></p>'" />
</template>
```  

Renders to:

```html
<div>Cats &amp; "Dogs"</div>
```

This behaviour will ignore any modifiers.

- Create a `strip-tags` argument that strips all tags
- Bump version to 2.3.0
- Update documentation