### PR TITLE
Tweak CI action for v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,16 @@
 name: CI
+
 on:
   push:
-    branches:
-      - "*"
+    branches: "*"
+
 jobs:
   build:
-    name: Install + Test + Build
     runs-on: ubuntu-latest
+    name: Install + Build + Test
     container: node:16.13-alpine
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: yarn
-      - run: yarn test
       - run: yarn build
+      - run: yarn test


### PR DESCRIPTION
Our GitHub action to build + test on push is currently broken and not reporting back, so we cannot easily verify that a PR doesn't break anything.

This PR updates the action to v3 (along with a couple of other minor tweaks).

I have also updated the repo settings to use the new action instead of the old as a status check, so we can see that this check now passes for this PR. Once merged, we should be able to push empty commits to the remaining open branches to get reliable status checks.