### PR TITLE
Provide ESM next to CJS builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vue-safe-html",
   "version": "2.2.0",
   "description": "A Vue directive which renders sanitised HTML dynamically",
-  "main": "dist/main.js",
+  "main": "dist/main.common.js",
+  "module": "dist/main.esm.js",
   "repository": "git@github.com:ecosia/vue-safe-html.git",
   "author": "Ecosia GmbH <opensource@ecosia.org>",
   "contributors": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,27 +1,45 @@
 const { resolve } = require('path');
 
-module.exports = {
-  entry: './src/index.js',
-  output: {
-    filename: 'main.js',
-    path: resolve(__dirname, 'dist'),
-    library: 'VueSafeHTML',
-    libraryTarget: 'umd',
-    globalObject: '(typeof self !== \'undefined\' ? self : this)',
-  },
-  mode: 'production',
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        exclude: /node_modules/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: ['@babel/preset-env'],
-          },
+const _module = {
+  rules: [
+    {
+      test: /\.js$/,
+      exclude: /node_modules/,
+      use: {
+        loader: 'babel-loader',
+        options: {
+          presets: ['@babel/preset-env'],
         },
       },
-    ],
-  },
+    },
+  ],
 };
+
+module.exports = [
+  {
+    entry: './src/index.js',
+    output: {
+      filename: 'main.common.js',
+      path: resolve(__dirname, 'dist'),
+      library: 'VueSafeHTML',
+      libraryTarget: 'commonjs2',
+      globalObject: '(typeof self !== \'undefined\' ? self : this)',
+    },
+    mode: 'production',
+    module: _module,
+  },
+  {
+    entry: './src/index.js',
+    output: {
+      filename: 'main.esm.js',
+      path: resolve(__dirname, 'dist'),
+      libraryTarget: 'module',
+      globalObject: '(typeof self !== \'undefined\' ? self : this)',
+    },
+    mode: 'production',
+    experiments: {
+      outputModule: true, // Enable the "experiments.outputModule" option
+    },
+    module: _module,
+  },
+];


### PR DESCRIPTION
Enabled the two different output formats to ensure compatibility with various module systems.